### PR TITLE
UUID key feature

### DIFF
--- a/src/main/java/com/aerospike/load/AerospikeLoad.java
+++ b/src/main/java/com/aerospike/load/AerospikeLoad.java
@@ -555,9 +555,10 @@ public class AerospikeLoad implements Runnable {
 
 			// KEY
 			if (mappingDef.keyColumnDef == null) {
-				throw new Exception ("Mapping definition without key mapping");	
+				log.warn ("Mapping definition without key mapping. UUID Key will be ingested with every record");
+			}else {
+				updateColumnInfo(mappingDef.keyColumnDef.nameDef, columnNames);
 			}
-			updateColumnInfo(mappingDef.keyColumnDef.nameDef, columnNames);
 
 			// SET
 			if (mappingDef.setColumnDef.staticName == null) {
@@ -641,13 +642,16 @@ public class AerospikeLoad implements Runnable {
 	}
 
 	private static void validateKeyNameInfo(MetaDefinition metadataColDef) throws Exception {
-		
-		if (metadataColDef.nameDef.columnPos < 0 && (metadataColDef.nameDef.columnName == null)) {
-			throw new Exception("Information missing(columnName, columnPos) in config file: " + metadataColDef);
-		}
+		if(metadataColDef!=null) {
 
-		if (metadataColDef.nameDef.srcType == null) {
-			throw new Exception("Source data type is not properly mentioned: " + metadataColDef);
+			if (metadataColDef.nameDef.columnPos < 0 && (metadataColDef.nameDef.columnName == null)) {
+				throw new Exception("Information missing(columnName, columnPos) in config file: " + metadataColDef);
+			}
+
+			if (metadataColDef.nameDef.srcType == null) {
+				throw new Exception("Source data type is not properly mentioned: " + metadataColDef);
+			}
+
 		}
 	}
 

--- a/src/main/java/com/aerospike/load/AsWriterTask.java
+++ b/src/main/java/com/aerospike/load/AsWriterTask.java
@@ -24,10 +24,7 @@ package com.aerospike.load;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.Callable;
 
 import org.apache.logging.log4j.LogManager;
@@ -295,24 +292,28 @@ public class AsWriterTask implements Callable<Integer> {
 		Key key = null;
 
 		MetaDefinition keyColumn = this.mappingDef.keyColumnDef;
-		
-		String keyRawText = this.columns.get(keyColumn.nameDef.columnPos);
-		
-		if (keyRawText == null || keyRawText.trim().length() == 0) {
-			counters.write.keyNullSkipped.getAndIncrement();
-			throw new Exception("Key value is null in datafile.");
-		}
+		if(keyColumn!=null) {
 
-		if ((keyColumn.nameDef.removePrefix != null)
-				&& (keyRawText.startsWith(keyColumn.nameDef.removePrefix))) {
-			keyRawText = keyRawText.substring(keyColumn.nameDef.removePrefix.length());
-		}
+			String keyRawText = this.columns.get(keyColumn.nameDef.columnPos);
 
-		if (keyColumn.nameDef.srcType == SrcColumnType.INTEGER) {
-			Long integer = Long.parseLong(keyRawText);
-			key = new Key(namespace, set, integer);
-		} else {
-			key = new Key(namespace, set, keyRawText);
+			if (keyRawText == null || keyRawText.trim().length() == 0) {
+				counters.write.keyNullSkipped.getAndIncrement();
+				throw new Exception("Key value is null in datafile.");
+			}
+
+			if ((keyColumn.nameDef.removePrefix != null)
+					&& (keyRawText.startsWith(keyColumn.nameDef.removePrefix))) {
+				keyRawText = keyRawText.substring(keyColumn.nameDef.removePrefix.length());
+			}
+
+			if (keyColumn.nameDef.srcType == SrcColumnType.INTEGER) {
+				Long integer = Long.parseLong(keyRawText);
+				key = new Key(namespace, set, integer);
+			} else {
+				key = new Key(namespace, set, keyRawText);
+			}
+		}else {
+			key=new Key(namespace,set, UUID.randomUUID().toString());
 		}
 
 		return key;

--- a/src/main/java/com/aerospike/load/Parser.java
+++ b/src/main/java/com/aerospike/load/Parser.java
@@ -205,8 +205,8 @@ public class Parser {
 		if ((obj = getFromJsonObject(mappingObj, Constants.KEY)) != null) {
 			keyColumnDef = getMetaDefs((JSONObject) obj, Constants.KEY);
 		} else {
-			log.error("\"" + Constants.KEY + "\"  Key is missing in mapping. Mapping: " + mappingObj.toString());
-			return null;
+			log.warn("\"" + Constants.KEY + "\"  Key is missing in mapping. Mapping: " + mappingObj.toString());
+			log.warn("UUID Key will be ingested with every record");
 		}
 
 

--- a/src/test/resources/configString.json
+++ b/src/test/resources/configString.json
@@ -1,6 +1,6 @@
 {
   "version" : "2.0",
-  "dsv_config": { "delimiter": "##" , "n_columns_datafile": 3, "header_exist": true},
+  "dsv_config": { "delimiter": "," , "n_columns_datafile": 3, "header_exist": true},
 
   "mappings": [
 	  {

--- a/src/test/resources/dataString.dsv
+++ b/src/test/resources/dataString.dsv
@@ -1,4 +1,4 @@
-set,key,strData
+set,key,stringData
 set1,key1,str1
 set2,key2,str2
 set3,key3,str3


### PR DESCRIPTION
UUID key will be ingested with every record if data files does not have primary key/ it has composite keys.
We can create secondary indexes on the columns and run analytical queries.

This pull is related to #13 