### PR TITLE
Update Java to latest version 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,8 +72,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.3.2</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
I'm not a Java developer or Maven expert, but I had to update the version of Java used in `pom.xml` in order to compile. I'm using a recently upgraded macOS Catalina with Maven 3.6.2 installed via Homebrew.

If versions can't be specified as "greater than" in `pom.xml`, and you want to avoid hardcoding this, perhaps there's room for a comment in the README.md?