### PR TITLE
fix: ensures context selection works- Fixes -v Debug Log Enablement

### DIFF
--- a/run_loader
+++ b/run_loader
@@ -4,4 +4,4 @@
 # Build with maven before running this script.
 # mvn install
 
-java -cp target/aerospike-load-*-jar-with-dependencies.jar com.aerospike.load.AerospikeLoad $*
+java -Dlog4j2.contextSelector=org.apache.logging.log4j.core.selector.BasicContextSelector -cp target/aerospike-load-*-jar-with-dependencies.jar com.aerospike.load.AerospikeLoad $*


### PR DESCRIPTION
This forces Log4j to use a simpler context selection strategy, reducing StackLocator usage.